### PR TITLE
LinkBench for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,22 @@ Running it without arguments will show a brief help message:
      -l                              Execute loading stage of benchmark
      -r                              Execute request stage of benchmark
 
+Building LinkBench for PostgreSQL
+---------------------------------
+To build LinkBench for PostgreSQL use profile 'pgsql'
+
+    cd linkbench
+    mvn clean package -P pgsql
+
+To skip all tests
+
+    mvn clean package -P pgsql -DskipTests
+
+If the build is successful, you should get a message like this at the end of the output:
+
+    BUILD SUCCESSFUL
+    Total time: 3 seconds
+
 Running a Benchmark with MySQL
 ==============================
 In this section we will document the process of setting
@@ -465,3 +481,123 @@ has permissions to create and drop tables.
 
 **If you implement a plugin for a new database, please consider contributing
 it back to the main LinkBench distribution with a pull request.**
+
+
+Running a Benchmark with PostgreSQL
+===================================
+
+* USE PostgreSQL 9.5 : 
+  for the UPSERT (INSERT ... ON CONFLICT KEY),
+	you should use PostgreSQL 9.5!!
+
+Setting up database and tables for PostgreSQL.
+To do this, there's ddl file in the project.
+
+	pgsql-ddl.sql
+
+PostgreSQL Setup
+-----------------
+We need to create a new database and tables on the PostgreSQL server.
+We'll create a new database called `linkdb` and
+the needed tables to store graph nodes, links and link counts.
+
+	1) run initdb (initialize database and templates) in shell
+		$> initdb -D linkdb
+		$> createdb		# this command make a default database
+
+	2) Run the following commands in the postgreSQL console:
+
+		$> psql 
+
+		--CREATE DATABASE for linkbench 
+		DROP DATABASE IF EXISTS linkdb;
+		CREATE DATABASE linkdb ENCODING='latin1' ;
+
+		--drop user linkbench to create new one
+		DROP USER  IF EXISTS linkbench;
+
+		--	You may want to set up a special database user account for benchmarking:
+		CREATE USER linkbench password 'password';
+		-- Grant all privileges on linkdb to this user
+		GRANT ALL ON database linkdb TO linkbench;
+
+	3) Connect to linkdb and create tables and index
+		
+		$> #conn postgresql linkbench/password
+    $> psql -Ulinkbench linkdb
+
+		--add Schema keep the same query style (dbid.table_name)
+		DROP SCHEMA IF EXISTS linkdb CASCADE; 
+		CREATE SCHEMA linkdb;
+
+		--FIXME:Need to make it partitioned by key id1 %16
+		CREATE TABLE linkdb.linktable (
+				id1 numeric(20) NOT NULL DEFAULT '0',
+				id2 numeric(20) NOT NULL DEFAULT '0',
+				link_type numeric(20) NOT NULL DEFAULT '0',
+				visibility smallint NOT NULL DEFAULT '0',
+				data varchar(255) NOT NULL DEFAULT '',
+				time numeric(20) NOT NULL DEFAULT '0',
+				version bigint NOT NULL DEFAULT '0',
+				PRIMARY KEY (link_type, id1,id2)
+				);
+
+		-- this is index for linktable
+		CREATE INDEX id1_type on linkdb.linktable(
+				id1,link_type,visibility,time,id2,version,data);
+
+		CREATE TABLE linkdb.counttable (
+				id numeric(20) NOT NULL DEFAULT '0',
+				link_type numeric(20) NOT NULL DEFAULT '0',
+				count int NOT NULL DEFAULT '0',
+				time numeric(20) NOT NULL DEFAULT '0',
+				version numeric(20) NOT NULL DEFAULT '0',
+				PRIMARY KEY (id,link_type)
+				);
+
+		CREATE TABLE linkdb.nodetable (
+				id BIGSERIAL NOT NULL,
+				type int NOT NULL,
+				version numeric NOT NULL,
+				time int NOT NULL,
+				data text NOT NULL,
+				PRIMARY KEY(id)
+				);
+
+Loading Data
+------------
+First we need to do an initial load of data using our new config file:
+
+    ./bin/linkbench -c config/LinkConfigPgsql.properties -l
+
+This will take a while to load, and you should get frequent progress updates.
+Once loading is finished you should see a notification like:
+
+    LOAD PHASE COMPLETED.  Loaded 10000000 nodes (Expected 10000000).
+      Loaded 47423071 links (4.74 links per node).  Took 620.4 seconds.
+      Links/second = 76435
+
+At the end LinkBench reports a range of statistics on load time that are
+of limited interest at this stage.
+
+Request Phase
+-------------
+Now you can do some benchmarking.
+Run the request phase using the below command:
+
+    ./bin/linkbench -c config/LinkConfigPgsql.properties -r
+
+LinkBench will log progress to the console, along with statistics.
+Once all requests have been sent, or the time limit has elapsed, LinkBench
+will notify you of completion:
+
+    REQUEST PHASE COMPLETED. 25000000 requests done in 2266 seconds.
+      Requests/second = 11029
+
+You can also inspect the latency statistics. For example, the following line tells us the mean latency
+for link range scan operations, along with latency ranges for median (p50), 99th percentile (p99) and
+so on.
+
+    GET_LINKS_LIST count = 12678653  p25 = [0.7,0.8]ms  p50 = [1,2]ms
+                   p75 = [1,2]ms  p95 = [10,11]ms  p99 = [15,16]ms
+                   max = 2064.476ms  mean = 2.427ms

--- a/config/LinkConfigPgsql.properties
+++ b/config/LinkConfigPgsql.properties
@@ -1,0 +1,130 @@
+# Sample MySQL LinkBench configuration file.
+#
+# This file contains settings for the data store, as well as controlling
+# benchmark output and behavior.  The workload is defined in a separate
+# file.
+# 
+# At a minimum to use this file, you will need to fill in MySQL
+# connection information.  
+
+##########################
+# Workload Configuration #
+##########################
+
+# Path for workload properties file.  Properties in this file will override
+# those in workload properties file.
+# Can be absolute path, or relative path from LinkBench home directory
+workload_file = config/FBWorkload.properties
+
+#################################
+#                               #
+#   Data Source Configuration   #
+#                               #
+#################################
+
+# Implementation of LinkStore and NodeStore to use 
+linkstore = com.facebook.LinkBench.LinkStorePgsql
+nodestore = com.facebook.LinkBench.LinkStorePgsql
+
+# MySQL connection information
+host = localhost
+user = woonhak
+password = woonhak
+port = 5432
+# dbid: the database name to use
+dbid = linkdb
+
+# database table names
+linktable = linktable
+# counttable not required for all databases
+counttable = counttable
+nodetable = nodetable
+
+###############################
+#                             #
+#   Logging and Stats Setup   #
+#                             #
+###############################
+
+# This controls logging output.  Settings are, in order of increasing
+# verbosity:
+# ERROR: only output serious errors
+# WARN: output warnings
+# INFO: output additional information such as progress
+# DEBUG: output high-level debugging information
+# TRACE: output more detailed lower-level debugging information
+debuglevel = INFO
+
+# display frequency of per-thread progress in seconds
+progressfreq = 300
+
+# display frequency of per-thread stats (latency, etc) in seconds
+displayfreq = 1800
+
+# display global load update (% complete, etc) after this many links loaded
+load_progress_interval = 50000
+
+# display global update on request phase (% complete, etc) after this many ops
+req_progress_interval = 10000
+
+# max number of samples to store for each per-thread statistic
+maxsamples = 10000
+
+###############################
+#                             #
+#  Load Phase Configuration   #
+#                             #
+###############################
+
+# number of threads to run during load phase
+loaders = 4
+
+# whether to generate graph nodes during load process
+generate_nodes = true
+
+# partition loading work into chunks of id1s of this size
+loader_chunk_size = 2048
+
+# seed for initial data load random number generation (optional)
+# load_random_seed = 12345
+
+##################################
+#                                #
+#  Request Phase Configuration   #
+#                                #
+##################################
+
+# number of threads to run during request phase
+requesters = 8
+
+# read + write requests per thread
+requests = 500000
+
+# request rate per thread.  <= 0 means unthrottled requests, > 0 limits
+#  the average request rate to that number of requests per second per thread,
+#  with the inter-request intervals governed by an exponential distribution
+requestrate = 0
+
+# max duration in seconds for request phase of benchmark
+maxtime = 100000
+
+# warmup time in seconds.  The benchmark is run for a warmup period
+# during which no statistics are recorded. This allows database caches,
+# etc to warm up.
+warmup_time = 0
+
+# seed for request random number generation (optional)
+# request_random_seed = 12345
+
+# maximum number of failures per requester to tolerate before aborting
+# negative number means never abort
+max_failed_requests = 100
+
+###############################
+#                             #
+#   PostgreSQL Tuning         #
+#                             #
+###############################
+
+# Optional tuning parameters
+

--- a/pgsql-ddl.sql
+++ b/pgsql-ddl.sql
@@ -1,0 +1,52 @@
+--create database for linkbench
+
+drop database if exists linkdb;
+create database linkdb encoding='latin1' ;
+
+--drop user linkbench to create new one
+DROP USER  IF EXISTS linkbench;
+
+--	You may want to set up a special database user account for benchmarking:
+CREATE USER linkbench password 'linkbench';
+-- Grant all privileges on linkdb to this user
+GRANT ALL ON database linkdb TO linkbench;
+
+--add Schema keep the same query style
+DROP SCHEMA IF EXISTS linkdb CASCADE; 
+CREATE SCHEMA linkdb;
+
+--conn postgresql linkbench/password
+
+--FIXME:Need to make it partitioned by key id1 %16
+CREATE TABLE linkdb.linktable (
+		id1 numeric(20) NOT NULL DEFAULT '0',
+		id2 numeric(20) NOT NULL DEFAULT '0',
+		link_type numeric(20) NOT NULL DEFAULT '0',
+		visibility smallint NOT NULL DEFAULT '0',
+		data varchar(255) NOT NULL DEFAULT '',
+		time numeric(20) NOT NULL DEFAULT '0',
+		version bigint NOT NULL DEFAULT '0',
+		PRIMARY KEY (link_type, id1,id2)
+		);
+
+-- this is index for linktable
+CREATE INDEX id1_type on linkdb.linktable(id1,link_type,visibility,time,id2,version,data);
+
+CREATE TABLE linkdb.counttable (
+		id numeric(20) NOT NULL DEFAULT '0',
+		link_type numeric(20) NOT NULL DEFAULT '0',
+		count int NOT NULL DEFAULT '0',
+		time numeric(20) NOT NULL DEFAULT '0',
+		version numeric(20) NOT NULL DEFAULT '0',
+		PRIMARY KEY (id,link_type)
+		);
+
+CREATE TABLE linkdb.nodetable (
+		id BIGSERIAL NOT NULL,
+		type int NOT NULL,
+		version numeric NOT NULL,
+		time int NOT NULL,
+		data text NOT NULL,
+		PRIMARY KEY(id)
+		);
+

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@
             <artifactId>mysql-connector-java</artifactId>
             <version>5.1.38</version>
         </dependency>
+
     </dependencies>
 
     <profiles>
@@ -138,6 +139,30 @@
                 </plugins>
             </build>
         </profile>
+				<!-- add new profile for PostgreSQL -->
+        <profile>
+            <id>pgsql</id>
+            <repositories>
+                <repository>
+                    <id>central</id>
+                    <url>http://repo1.maven.org/maven2</url>
+                    <releases>
+                        <enabled>true</enabled>
+                    </releases>
+                    <snapshots>
+                        <enabled>true</enabled>
+                    </snapshots>
+                </repository>
+            </repositories>
+						<!-- woonhak - add this for connect to PostgreSQL -->
+						<dependencies>
+        			<dependency>
+								<groupId>org.postgresql</groupId>
+								<artifactId>postgresql</artifactId>
+								<version>9.4.1207.jre7</version>
+        			</dependency>
+						</dependencies>
+        		</profile>
     </profiles>
 
     <build>

--- a/src/main/java/com/facebook/LinkBench/LinkStorePgsql.java
+++ b/src/main/java/com/facebook/LinkBench/LinkStorePgsql.java
@@ -1,0 +1,1228 @@
+/*
+ * LinkStore for PostgreSQL
+ * Author : woonhak.kang (woonhak.kang@gmail.com)
+ * Date : 01/26/2016
+ * 
+ * Original Copyright
+ * Copyright 2012, Facebook, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.LinkBench;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.CharBuffer;
+import java.nio.charset.Charset;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.log4j.Level;
+import org.apache.log4j.Logger;
+
+public class LinkStorePgsql extends GraphStore {
+
+  /* PostgreSQL database server configuration keys */
+  public static final String CONFIG_HOST = "host";
+  public static final String CONFIG_PORT = "port";
+  public static final String CONFIG_USER = "user";
+  public static final String CONFIG_PASSWORD = "password";
+  //public static final String CONFIG_BULK_INSERT_BATCH = "mysql_bulk_insert_batch";
+  //public static final String CONFIG_DISABLE_BINLOG_LOAD = "mysql_disable_binlog_load";
+
+	//XXX woonhak, test small bulk insert size (sometimes JDBC buffer got overflowed);
+  public static final int DEFAULT_BULKINSERT_SIZE = 128;
+
+  private static final boolean INTERNAL_TESTING = false;
+
+  String linktable;
+  String counttable;
+  String nodetable;
+
+  String host;
+  String user;
+  String pwd;
+  String port;
+  String defaultDB;
+
+  Level debuglevel;
+  // Use read-only and read-write connections and statements to avoid toggling
+  // auto-commit.
+  Connection conn_ro, conn_rw;
+  Statement stmt_ro, stmt_rw;
+
+  private Phase phase;
+
+  int bulkInsertSize = DEFAULT_BULKINSERT_SIZE;
+  // Optional optimization: disable binary logging
+  boolean disableBinLogForLoad = false;
+
+  private final Logger logger = Logger.getLogger(ConfigUtil.LINKBENCH_LOGGER);
+
+  public LinkStorePgsql() {
+    super();
+  }
+
+  public LinkStorePgsql(Properties props) throws IOException, Exception {
+    super();
+    initialize(props, Phase.LOAD, 0);
+  }
+
+  public void initialize(Properties props, Phase currentPhase,
+    int threadId) throws IOException, Exception {
+    counttable = ConfigUtil.getPropertyRequired(props, Config.COUNT_TABLE);
+    if (counttable.equals("")) {
+      String msg = "Error! " + Config.COUNT_TABLE + " is empty!"
+          + "Please check configuration file.";
+      logger.error(msg);
+      throw new RuntimeException(msg);
+    }
+
+    nodetable = props.getProperty(Config.NODE_TABLE);
+    if (nodetable.equals("")) {
+      // For now, don't assume that nodetable is provided
+      String msg = "Error! " + Config.NODE_TABLE + " is empty!"
+          + "Please check configuration file.";
+      logger.error(msg);
+      throw new RuntimeException(msg);
+    }
+
+    host = ConfigUtil.getPropertyRequired(props, CONFIG_HOST);
+    user = ConfigUtil.getPropertyRequired(props, CONFIG_USER);
+    pwd = ConfigUtil.getPropertyRequired(props, CONFIG_PASSWORD);
+    port = props.getProperty(CONFIG_PORT);
+    defaultDB = ConfigUtil.getPropertyRequired(props, Config.DBID);
+
+    if (port == null || port.equals("")) port = "5432"; //use default port
+    debuglevel = ConfigUtil.getDebugLevel(props);
+    phase = currentPhase;
+
+		/*woonhak, Disable additional configurations */
+//    if (props.containsKey(CONFIG_BULK_INSERT_BATCH)) {
+//      bulkInsertSize = ConfigUtil.getInt(props, CONFIG_BULK_INSERT_BATCH);
+//    }
+//    if (props.containsKey(CONFIG_DISABLE_BINLOG_LOAD)) {
+//      disableBinLogForLoad = ConfigUtil.getBool(props,
+//                                      CONFIG_DISABLE_BINLOG_LOAD);
+//    }
+
+    // connect
+    try {
+      openConnection();
+    } catch (Exception e) {
+      logger.error("error connecting to database:", e);
+      throw e;
+    }
+
+    linktable = ConfigUtil.getPropertyRequired(props, Config.LINK_TABLE);
+  }
+
+  // connects to test database
+  private void openConnection() throws Exception {
+    conn_ro = null;
+    conn_rw = null;
+    stmt_ro = null;
+    stmt_rw = null;
+
+    String jdbcUrl = "jdbc:postgresql://"+ host + ":" + port + "/";
+    if (defaultDB != null) {
+      jdbcUrl += defaultDB;
+    }
+
+    Class.forName("org.postgresql.Driver").newInstance();
+
+		/* XXX woonhak - I add a SCHEMA for access tables using 'dbid.table_name' style.
+		   to do so, we need to set 'search_path' for the our schema,
+		   I guess schema name is the same as dbname */
+    jdbcUrl += "?searchpath=" + defaultDB ;
+
+    jdbcUrl += "?elideSetAutoCommits=true" +
+               "&useLocalTransactionState=true" +
+               "&allowMultiQueries=true" +
+               "&useLocalSessionState=true" +
+   /* Need affected row count from queries to distinguish updates/inserts
+    * consistently across different MySql versions (see MySql bug 46675) */
+               "&useAffectedRows=true";
+
+
+
+
+    conn_rw = DriverManager.getConnection(jdbcUrl, user, pwd);
+    conn_rw.setAutoCommit(false);
+
+    conn_ro = DriverManager.getConnection(jdbcUrl, user, pwd);
+    conn_ro.setAutoCommit(true);
+
+    //System.err.println("connected");
+    stmt_rw = conn_rw.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+                                      ResultSet.CONCUR_READ_ONLY);
+    stmt_ro = conn_ro.createStatement(ResultSet.TYPE_SCROLL_INSENSITIVE,
+                                      ResultSet.CONCUR_READ_ONLY);
+
+		//XXX woonhak, check metadata pgsql JDBC driver support getGeneratedKeys() - probably not
+		//dmd = conn.getMetadata() and then run dmd.supportsGetGeneratedKeys()
+
+		/*disabled under pgsql */
+//    if (phase == Phase.LOAD && disableBinLogForLoad) {
+//      // Turn binary logging off for duration of connection
+//      stmt_rw.executeUpdate("SET SESSION sql_log_bin=0");
+//      stmt_ro.executeUpdate("SET SESSION sql_log_bin=0");
+//    }
+  }
+
+  @Override
+  public void close() {
+    try {
+      if (stmt_rw != null) stmt_rw.close();
+      if (stmt_ro != null) stmt_ro.close();
+      if (conn_rw != null) conn_rw.close();
+      if (conn_ro != null) conn_ro.close();
+    } catch (SQLException e) {
+      logger.error("Error while closing PostgreSQL connection: ", e);
+    }
+  }
+
+  public void clearErrors(int threadID) {
+    logger.info("Reopening Pgsql connection in threadID " + threadID);
+
+    try {
+      if (conn_rw != null) {
+        conn_rw.close();
+      }
+      if (conn_ro != null) {
+        conn_ro.close();
+      }
+
+      openConnection();
+    } catch (Throwable e) {
+      e.printStackTrace();
+      return;
+    }
+  }
+
+  /**
+   * Set of all JDBC SQLState strings that indicate a transient MySQL error
+   * that should be handled by retrying
+   */
+  private static final HashSet<String> retrySQLStates = populateRetrySQLStates();
+
+
+	/**
+	 * FIXME : woonhak check Error Code */
+
+  /**
+   *  Populate retrySQLStates
+   *  SQLState codes are defined in MySQL Connector/J documentation:
+   *  http://dev.mysql.com/doc/refman/5.6/en/connector-j-reference-error-sqlstates.html
+   */
+  private static HashSet<String> populateRetrySQLStates() {
+    HashSet<String> states = new HashSet<String>();
+    states.add("41000"); // ER_LOCK_WAIT_TIMEOUT
+    states.add("40001"); // ER_LOCK_DEADLOCK
+    return states;
+  }
+
+  /**
+   * Handle SQL exception by logging error and selecting how to respond
+   * @param ex SQLException thrown by PgSQL JDBC driver
+   * @return true if transaction should be retried
+   */
+  private boolean processSQLException(SQLException ex, String op) {
+    boolean retry = retrySQLStates.contains(ex.getSQLState());
+    String msg = "SQLException thrown by PgSQL driver during execution of " +
+                 "operation: " + op + ".  ";
+    msg += "Message was: '" + ex.getMessage() + "'.  ";
+    msg += "SQLState was: " + ex.getSQLState() + ".  ";
+
+    if (retry) {
+      msg += "Error is probably transient, retrying operation.";
+      logger.warn(msg);
+    } else {
+      msg += "Error is probably non-transient, will abort operation.";
+      logger.error(msg);
+    }
+    return retry;
+  }
+
+  // get count for testing purpose
+  private void testCount(Statement stmt, String dbid,
+                         String assoctable, String counttable,
+                         long id, long link_type)
+    throws Exception {
+
+    String select1 = "SELECT COUNT(id2)" +
+                     " FROM " + dbid + "." + assoctable +
+                     " WHERE id1 = " + id +
+                     " AND link_type = " + link_type +
+                     " AND visibility = " + LinkStore.VISIBILITY_DEFAULT;
+
+    String select2 = "SELECT COALESCE (SUM(count), 0)" +
+                     " FROM " + dbid + "." + counttable +
+                     " WHERE id = " + id +
+                     " AND link_type = " + link_type;
+
+    String verify = "SELECT IF ((" + select1 +
+                    ") = (" + select2 + "), 1, 0) as result";
+
+    ResultSet result = stmt.executeQuery(verify);
+
+    int ret = -1;
+    while (result.next()) {
+      ret = result.getInt("result");
+    }
+
+    if (ret != 1) {
+      throw new Exception("Data inconsistency between " + assoctable +
+                          " and " + counttable);
+    }
+  }
+
+  @Override
+  public boolean addLink(String dbid, Link l, boolean noinverse)
+    throws Exception {
+    while (true) {
+      try {
+        return addLinkImpl(dbid, l, noinverse);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "addLink")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private boolean addLinkImpl(String dbid, Link l, boolean noinverse)
+      throws Exception {
+
+     if (Level.DEBUG.isGreaterOrEqual(debuglevel)) {
+      logger.debug("addLink " + l.id1 +
+                         "." + l.id2 +
+                         "." + l.link_type);
+    }
+
+    // if the link is already there then update its visibility
+    // only update visibility; skip updating time, version, etc.
+
+    int nrows = addLinksNoCount(dbid, Collections.singletonList(l));
+
+    // Note: at this point, we have an exclusive lock on the link
+    // row until the end of the transaction, so can safely do
+    // further updates without concurrency issues.
+
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace("nrows = " + nrows);
+    }
+
+    // based on nrows, determine whether the previous query was an insert
+    // or update
+    boolean row_found;
+    boolean update_data = false;
+    int update_count = 0;
+
+    switch (nrows) {
+      case 1:
+        // a new row was inserted --> need to update counttable
+        if (l.visibility == VISIBILITY_DEFAULT) {
+          update_count = 1;
+        }
+        row_found = false;
+        break;
+
+      case 0:
+        // A row is found but its visibility was unchanged
+        // --> need to update other data
+        update_data = true;
+        row_found = true;
+        break;
+
+      case 2:
+        // a visibility was changed from VISIBILITY_HIDDEN to DEFAULT
+        // or vice-versa
+        // --> need to update both counttable and other data
+        if (l.visibility == VISIBILITY_DEFAULT) {
+          update_count = 1;
+        } else {
+          update_count = -1;
+        }
+        update_data = true;
+        row_found = true;
+        break;
+
+      default:
+        String msg = "Value of affected-rows number is not valid" + nrows;
+        logger.error("SQL Error: " + msg);
+        throw new Exception(msg);
+    }
+
+    if (update_count != 0) {
+      int base_count = update_count < 0 ? 0 : 1;
+      // query to update counttable
+      // if (id, link_type) is not there yet, add a new record with count = 1
+      // The update happens atomically, with the latest count and version
+      long currentTime = (new Date()).getTime();
+
+			/*XXX - woonhak - PostgeSQL Style UPSERT */
+      String updatecount = "INSERT INTO " + dbid + "." + counttable +
+                      "(id, link_type, count, time, version) " +
+                      "VALUES (" + l.id1 +
+                      ", " + l.link_type +
+                      ", " + base_count +
+                      ", " + currentTime +
+                      ", " + 0 + ") " +
+                      "ON CONFLICT ON CONSTRAINT " + counttable + "_pkey DO UPDATE SET " +
+                      " count = count + " + update_count +
+                      ", version = version + 1 " +
+                      ", time = " + currentTime + ";";
+
+      if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+        logger.trace(updatecount);
+      }
+
+      // This is the last statement of transaction - append commit to avoid
+      // extra round trip
+      if (!update_data) {
+        updatecount += " commit;";
+      }
+      stmt_rw.executeUpdate(updatecount);
+    }
+
+    if (update_data) {
+      // query to update link data (the first query only updates visibility)
+      String updatedata = "UPDATE linktable SET " +
+                  " visibility = " + l.visibility +
+                  //", data = convert_from(decode(" +  stringLiteral(l.data) + 
+									//", 'hex'), 'LATIN1')" +
+                  ", data = convert_from(" +  stringLiteral(l.data) + ", 'LATIN1')" +
+                  ", time = " + l.time +
+                  ", version = " + l.version +
+                  " WHERE id1 = " + l.id1 +
+                  " AND id2 = " + l.id2 +
+                  " AND link_type = " + l.link_type + "; commit;";
+      if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+        logger.trace(updatedata);
+      }
+
+      stmt_rw.executeUpdate(updatedata);
+    }
+
+    if (INTERNAL_TESTING) {
+      testCount(stmt_ro, dbid, linktable, counttable, l.id1, l.link_type);
+    }
+    return row_found;
+  }
+
+  /**
+   * Internal method: add links without updating the count
+   * @param dbid
+   * @param links
+   * @return
+   * @throws SQLException
+   */
+  private int addLinksNoCount(String dbid, List<Link> links)
+      throws SQLException {
+    if (links.size() == 0)
+      return 0;
+
+    // query to insert a link;
+    StringBuilder sb = new StringBuilder();
+    sb.append("INSERT INTO " + dbid + "." + linktable +
+                    "(id1, id2, link_type, " +
+                    "visibility, data, time, version) VALUES ");
+    boolean first = true;
+    for (Link l : links) {
+      if (first) {
+        first = false;
+      } else {
+        sb.append(',');
+      }
+      sb.append("(" + l.id1 +
+          ", " + l.id2 +
+          ", " + l.link_type +
+          ", " + l.visibility +
+          //", " + stringLiteral(l.data) +
+          //", convert_from(decode(" +  stringLiteral(l.data) + ", 'hex'), 'LATIN1')" +
+          ", convert_from(" +  stringLiteral(l.data) + ", 'LATIN1')" +
+          ", " + l.time + ", " +
+          l.version + ")");
+    }
+    //sb.append(" ON DUPLICATE KEY UPDATE visibility = VALUES(visibility)");
+		//XXX woonhak - Postgresql Style Upsert 
+    sb.append(" ON CONFLICT ON CONSTRAINT " + linktable +"_pkey DO UPDATE SET visibility = EXCLUDED.visibility");
+    String insert = sb.toString();
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace(insert);
+    }
+
+    int nrows = stmt_rw.executeUpdate(insert);
+    return nrows;
+}
+
+  @Override
+  public boolean deleteLink(String dbid, long id1, long link_type, long id2,
+                         boolean noinverse, boolean expunge)
+    throws Exception {
+    while (true) {
+      try {
+        return deleteLinkImpl(dbid, id1, link_type, id2, noinverse, expunge);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "deleteLink")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private boolean deleteLinkImpl(String dbid, long id1, long link_type, long id2,
+      boolean noinverse, boolean expunge) throws Exception {
+    if (Level.DEBUG.isGreaterOrEqual(debuglevel)) {
+      logger.debug("deleteLink " + id1 +
+                         "." + id2 +
+                         "." + link_type);
+    }
+
+    // First do a select to check if the link is not there, is there and
+    // hidden, or is there and visible;
+    // Result could be either NULL, VISIBILITY_HIDDEN or VISIBILITY_DEFAULT.
+    // In case of VISIBILITY_DEFAULT, later we need to mark the link as
+    // hidden, and update counttable.
+    // We lock the row exclusively because we rely on getting the correct
+    // value of visible to maintain link counts.  Without the lock,
+    // a concurrent transaction could also see the link as visible and
+    // we would double-decrement the link count.
+    String select = "SELECT visibility" +
+                    " FROM " + dbid + "." + linktable +
+                    " WHERE id1 = " + id1 +
+                    " AND id2 = " + id2 +
+                    " AND link_type = " + link_type +
+                    " FOR UPDATE;";
+
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace(select);
+    }
+
+    ResultSet result = stmt_rw.executeQuery(select);
+
+    int visibility = -1;
+    boolean found = false;
+    while (result.next()) {
+      visibility = result.getInt("visibility");
+      found = true;
+    }
+
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace(String.format("(%d, %d, %d) visibility = %d",
+                id1, link_type, id2, visibility));
+    }
+
+    if (!found) {
+      // do nothing
+    }
+    else if (visibility == VISIBILITY_HIDDEN && !expunge) {
+      // do nothing
+    }
+    else {
+      // Only update count if link is present and visible
+      boolean updateCount = (visibility != VISIBILITY_HIDDEN);
+
+      // either delete or mark the link as hidden
+      String delete;
+
+      if (!expunge) {
+        delete = "UPDATE " + dbid + "." + linktable +
+                 " SET visibility = " + VISIBILITY_HIDDEN +
+                 " WHERE id1 = " + id1 +
+                 " AND id2 = " + id2 +
+                 " AND link_type = " + link_type + ";";
+      } else {
+        delete = "DELETE FROM " + dbid + "." + linktable +
+                 " WHERE id1 = " + id1 +
+                 " AND id2 = " + id2 +
+                 " AND link_type = " + link_type + ";";
+      }
+
+      if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+        logger.trace(delete);
+      }
+
+      stmt_rw.executeUpdate(delete);
+
+      // update count table
+      // * if found (id1, link_type) in count table, set
+      //   count = (count == 1) ? 0) we decrease the value of count
+      //   column by 1;
+      // * otherwise, insert new link with count column = 0
+      // The update happens atomically, with the latest count and version
+      long currentTime = (new Date()).getTime();
+      String update = "INSERT INTO " + dbid + "." + counttable +
+                      " (id, link_type, count, time, version) " +
+                      "VALUES (" + id1 +
+                      ", " + link_type +
+                      ", 0" +
+                      ", " + currentTime +
+                      ", " + 0 + ") " +
+                      "ON DUPLICATE KEY UPDATE" +
+                      " count = IF (count = 0, 0, count - 1)" +
+                      ", time = " + currentTime +
+                      ", version = version + 1;";
+
+      if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+        logger.trace(update);
+      }
+
+      stmt_rw.executeUpdate(update);
+    }
+
+    conn_rw.commit();
+
+    if (INTERNAL_TESTING) {
+      testCount(stmt_ro, dbid, linktable, counttable, id1, link_type);
+    }
+
+    return found;
+  }
+
+  @Override
+  public boolean updateLink(String dbid, Link l, boolean noinverse)
+    throws Exception {
+    // Retry logic is in addLink
+    boolean added = addLink(dbid, l, noinverse);
+    return !added; // return true if updated instead of added
+  }
+
+
+  // lookup using id1, type, id2
+  @Override
+  public Link getLink(String dbid, long id1, long link_type, long id2)
+    throws Exception {
+    while (true) {
+      try {
+        return getLinkImpl(dbid, id1, link_type, id2);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "getLink")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private Link getLinkImpl(String dbid, long id1, long link_type, long id2)
+    throws Exception {
+    Link res[] = multigetLinks(dbid, id1, link_type, new long[] {id2});
+    if (res == null) return null;
+    assert(res.length <= 1);
+    return res.length == 0 ? null : res[0];
+  }
+
+
+  @Override
+  public Link[] multigetLinks(String dbid, long id1, long link_type,
+                              long[] id2s) throws Exception {
+    while (true) {
+      try {
+        return multigetLinksImpl(dbid, id1, link_type, id2s);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "multigetLinks")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private Link[] multigetLinksImpl(String dbid, long id1, long link_type,
+                                long[] id2s) throws Exception {
+    StringBuilder querySB = new StringBuilder();
+    querySB.append(" select id1, id2, link_type," +
+        " visibility, data, time, " +
+        " version from " + dbid + "." + linktable +
+        " where id1 = " + id1 + " and link_type = " + link_type +
+        " and id2 in (");
+    boolean first = true;
+    for (long id2: id2s) {
+      if (first) {
+        first = false;
+      } else {
+        querySB.append(",");
+      }
+      querySB.append(id2);
+    }
+
+    querySB.append(");");
+    String query = querySB.toString();
+
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace("Query is " + query);
+    }
+
+    ResultSet rs = stmt_ro.executeQuery(query);
+
+    // Get the row count to allocate result array
+    assert(rs.getType() != ResultSet.TYPE_FORWARD_ONLY);
+    rs.last();
+    int count = rs.getRow();
+    rs.beforeFirst();
+
+    Link results[] = new Link[count];
+    int i = 0;
+    while (rs.next()) {
+      Link l = createLinkFromRow(rs);
+      if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+        logger.trace("Lookup result: " + id1 + "," + link_type + "," +
+                  l.id2 + " found");
+      }
+      results[i++] = l;
+    }
+    return results;
+  }
+
+  // lookup using just id1, type
+  @Override
+  public Link[] getLinkList(String dbid, long id1, long link_type)
+    throws Exception {
+    // Retry logic in getLinkList
+    return getLinkList(dbid, id1, link_type, 0, Long.MAX_VALUE, 0, rangeLimit);
+  }
+
+  @Override
+  public Link[] getLinkList(String dbid, long id1, long link_type,
+                            long minTimestamp, long maxTimestamp,
+                            int offset, int limit)
+    throws Exception {
+    while (true) {
+      try {
+        return getLinkListImpl(dbid, id1, link_type, minTimestamp,
+                               maxTimestamp, offset, limit);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "getLinkListImpl")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private Link[] getLinkListImpl(String dbid, long id1, long link_type,
+        long minTimestamp, long maxTimestamp,
+        int offset, int limit)
+            throws Exception {
+    String query = " select id1, id2, link_type," +
+                   " visibility, data, time," +
+                   " version from " + dbid + "." + linktable +
+									 //XXX woonhak PostgreSQL does not allow to use hints for QP.
+                   //" FORCE INDEX(`id1_type`) " +
+                   " where id1 = " + id1 + " and link_type = " + link_type +
+                   " and time >= " + minTimestamp +
+                   " and time <= " + maxTimestamp +
+                   " and visibility = " + LinkStore.VISIBILITY_DEFAULT +
+                   " order by time desc " +
+                   //" limit " + offset + "," + limit + ";";
+									 //XXX woonhak PostgreSQL LIMIT  #,# not supported -> LIMIT # OFFSET #
+                   " LIMIT " + limit +  " OFFSET " + offset + ";";
+
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace("Query is " + query);
+    }
+
+    ResultSet rs = stmt_ro.executeQuery(query);
+
+    // Find result set size
+    // be sure we fast forward to find result set size
+    assert(rs.getType() != ResultSet.TYPE_FORWARD_ONLY);
+    rs.last();
+    int count = rs.getRow();
+    rs.beforeFirst();
+
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace("Range lookup result: " + id1 + "," + link_type +
+                         " is " + count);
+    }
+    if (count == 0) {
+      return null;
+    }
+
+    // Fetch the link data
+    Link links[] = new Link[count];
+    int i = 0;
+    while (rs.next()) {
+      Link l = createLinkFromRow(rs);
+      links[i] = l;
+      i++;
+    }
+    assert(i == count);
+    return links;
+  }
+
+  private Link createLinkFromRow(ResultSet rs) throws SQLException {
+    Link l = new Link();
+    l.id1 = rs.getLong(1);
+    l.id2 = rs.getLong(2);
+    l.link_type = rs.getLong(3);
+    l.visibility = rs.getByte(4);
+    l.data = rs.getBytes(5);
+    l.time = rs.getLong(6);
+    l.version = rs.getInt(7);
+    return l;
+  }
+
+  // count the #links
+  @Override
+  public long countLinks(String dbid, long id1, long link_type)
+    throws Exception {
+    while (true) {
+      try {
+        return countLinksImpl(dbid, id1, link_type);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "countLinks")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private long countLinksImpl(String dbid, long id1, long link_type)
+        throws Exception {
+    long count = 0;
+    String query = " select count from " + dbid + "." + counttable +
+                   " where id = " + id1 + " and link_type = " + link_type + ";";
+
+    ResultSet rs = stmt_ro.executeQuery(query);
+    boolean found = false;
+
+    while (rs.next()) {
+      // found
+      if (found) {
+        logger.trace("Count query 2nd row!: " + id1 + "," + link_type);
+      }
+
+      found = true;
+      count = rs.getLong(1);
+    }
+
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace("Count result: " + id1 + "," + link_type +
+                         " is " + found + " and " + count);
+    }
+
+    return count;
+  }
+
+  @Override
+  public int bulkLoadBatchSize() {
+    return bulkInsertSize;
+  }
+
+  @Override
+  public void addBulkLinks(String dbid, List<Link> links, boolean noinverse)
+      throws Exception {
+    while (true) {
+      try {
+        addBulkLinksImpl(dbid, links, noinverse);
+        return;
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "addBulkLinks")) {
+          throw ex;
+        }
+      }
+    }
+  }
+    boolean first = true;
+
+  private void addBulkLinksImpl(String dbid, List<Link> links, boolean noinverse)
+      throws Exception {
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace("addBulkLinks: " + links.size() + " links");
+    }
+
+    addLinksNoCount(dbid, links);
+    conn_rw.commit();
+  }
+
+  @Override
+  public void addBulkCounts(String dbid, List<LinkCount> counts)
+                                                throws Exception {
+    while (true) {
+      try {
+        addBulkCountsImpl(dbid, counts);
+        return;
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "addBulkCounts")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private void addBulkCountsImpl(String dbid, List<LinkCount> counts)
+                                                throws Exception {
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace("addBulkCounts: " + counts.size() + " link counts");
+    }
+    if (counts.size() == 0)
+      return;
+
+    StringBuilder sqlSB = new StringBuilder();
+
+		/*
+    sqlSB.append("REPLACE INTO " + dbid + "." + counttable +
+        "(id, link_type, count, time, version) " +
+        "VALUES ");
+    boolean first = true;
+    for (LinkCount count: counts) {
+      if (first) {
+        first = false;
+      } else {
+        sqlSB.append(",");
+      }
+    boolean first = true;
+      sqlSB.append("(" + count.id1 +
+        ", " + count.link_type +
+        ", " + count.count +
+        ", " + count.time +
+        ", " + count.version + ")");
+    }
+
+    String sql = sqlSB.toString();
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace(sql);
+    }
+    stmt_rw.executeUpdate(sql);
+    conn_rw.commit();
+		*/
+
+		/*XXX woonhak, there's no replace into,
+			so need to DELETE unconditionally,
+			then INSERT NEW values */
+    for (LinkCount count: counts) {
+			sqlSB.append("DELETE FROM " + dbid + "." + counttable +
+					" where id = "+ count.id1 +
+					" and link_type = " + count.link_type +
+					"; ");
+      sqlSB.append("INSERT INTO " + dbid + "." + counttable +
+					"(id, link_type, count, time, version) " +
+					"VALUES (" + count.id1 +
+        ", " + count.link_type +
+        ", " + count.count +
+        ", " + count.time +
+        ", " + count.version + ")");
+        sqlSB.append(";");
+    }
+
+    String sql = sqlSB.toString();
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace(sql);
+    }
+    stmt_rw.executeUpdate(sql);
+    conn_rw.commit();
+  }
+
+  private void checkNodeTableConfigured() throws Exception {
+    if (this.nodetable == null) {
+      throw new Exception("Nodetable not specified: cannot perform node" +
+          " operation");
+    }
+  }
+
+
+	/*FIXME : woonhak,
+		these kind of dbid is same as schema of PostgreSQL,
+		so I might need to change this */
+  @Override
+  public void resetNodeStore(String dbid, long startID) throws Exception {
+    checkNodeTableConfigured();
+    // Truncate table deletes all data and allows us to reset autoincrement
+		stmt_rw.execute(String.format("TRUNCATE TABLE %s.%s;",
+					             dbid, nodetable));
+		/*
+    stmt_rw.execute(String.format("ALTER TABLE `%s`.`%s` " +
+        "AUTO_INCREMENT = %d;", dbid, nodetable, startID));
+		*/
+    stmt_rw.execute(String.format("ALTER SEQUENCE %s.nodetable_id_seq RESTART %d;",
+					dbid, startID));
+  }
+
+  @Override
+  public long addNode(String dbid, Node node) throws Exception {
+    while (true) {
+      try {
+        return addNodeImpl(dbid, node);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "addNode")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private long addNodeImpl(String dbid, Node node) throws Exception {
+    long ids[] = bulkAddNodes(dbid, Collections.singletonList(node));
+    assert(ids.length == 1);
+    return ids[0];
+  }
+
+  @Override
+  public long[] bulkAddNodes(String dbid, List<Node> nodes) throws Exception {
+    while (true) {
+      try {
+        return bulkAddNodesImpl(dbid, nodes);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "bulkAddNodes")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private long[] bulkAddNodesImpl(String dbid, List<Node> nodes) throws Exception {
+    checkNodeTableConfigured();
+    StringBuilder sql = new StringBuilder();
+    sql.append("INSERT INTO " + dbid + "." + nodetable + " " +
+        "(type, version, time, data) " +
+        "VALUES ");
+    boolean first = true;
+    for (Node node: nodes) {
+      if (first) {
+        first = false;
+      } else {
+        sql.append(",");
+      }
+      sql.append("(" + node.type + "," + node.version +
+          "," + node.time + "," + 
+					//stringLiteral(node.data) + 
+          //"convert_from(decode(" +  stringLiteral(node.data) + ", 'hex'), 'LATIN1')" +
+          "convert_from(" +  stringLiteral(node.data) + ", 'LATIN1')" +
+					")");
+    }
+    //sql.append("; commit;");
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace(sql);
+    }
+
+		//XXX woonhak, 
+    stmt_rw.executeUpdate(sql.toString(), Statement.RETURN_GENERATED_KEYS);
+    ResultSet rs = stmt_rw.getGeneratedKeys();
+
+    long newIds[] = new long[nodes.size()];
+    // Find the generated id
+    int i = 0;
+    while (rs.next() && i < nodes.size()) {
+      newIds[i++] = rs.getLong(1);
+    }
+
+    if (i != nodes.size()) {
+      throw new Exception("Wrong number of generated keys on insert: "
+          + " expected " + nodes.size() + " actual " + i);
+    }
+
+    assert(!rs.next()); // check done
+    rs.close();
+
+    return newIds;
+  }
+
+  @Override
+  public Node getNode(String dbid, int type, long id) throws Exception {
+    while (true) {
+      try {
+        return getNodeImpl(dbid, type, id);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "getNode")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private Node getNodeImpl(String dbid, int type, long id) throws Exception {
+    checkNodeTableConfigured();
+    ResultSet rs = stmt_ro.executeQuery(
+      "SELECT id, type, version, time, data " +
+      "FROM " + dbid + "." + nodetable + " " +
+      "WHERE id=" + id + ";");
+    if (rs.next()) {
+      Node res = new Node(rs.getLong(1), rs.getInt(2),
+           rs.getLong(3), rs.getInt(4), rs.getBytes(5));
+
+      // Check that multiple rows weren't returned
+      assert(rs.next() == false);
+      rs.close();
+      if (res.type != type) {
+        return null;
+      } else {
+        return res;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public boolean updateNode(String dbid, Node node) throws Exception {
+    while (true) {
+      try {
+        return updateNodeImpl(dbid, node);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "updateNode")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private boolean updateNodeImpl(String dbid, Node node) throws Exception {
+    checkNodeTableConfigured();
+									 //XXX woonhak - little bit complicated converting
+									 //stringLiteral(node.data) +
+    String sql = "UPDATE " + dbid + "." + nodetable +
+            " SET " + "version=" + node.version + ", time=" + node.time
+                   + ", data=" +
+									 //"convert_from(decode(" +  stringLiteral(node.data) + ", 'hex'), 'LATIN1')" +
+									 "convert_from(" +  stringLiteral(node.data) + ", 'LATIN1')" +
+            " WHERE id=" + node.id + " AND type=" + node.type + "; commit;";
+
+    if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
+      logger.trace(sql);
+    }
+
+    int rows = stmt_rw.executeUpdate(sql);
+
+    if (rows == 1) return true;
+    else if (rows == 0) return false;
+    else throw new Exception("Did not expect " + rows +  "affected rows: only "
+        + "expected update to affect at most one row");
+  }
+
+  @Override
+  public boolean deleteNode(String dbid, int type, long id) throws Exception {
+    while (true) {
+      try {
+        return deleteNodeImpl(dbid, type, id);
+      } catch (SQLException ex) {
+        if (!processSQLException(ex, "deleteNode")) {
+          throw ex;
+        }
+      }
+    }
+  }
+
+  private boolean deleteNodeImpl(String dbid, int type, long id) throws Exception {
+    checkNodeTableConfigured();
+    int rows = stmt_rw.executeUpdate(
+        "DELETE FROM " + dbid + "." + nodetable + " " +
+        "WHERE id=" + id + " and type =" + type + "; commit;");
+
+    if (rows == 0) {
+      return false;
+    } else if (rows == 1) {
+      return true;
+    } else {
+      throw new Exception(rows + " rows modified on delete: should delete " +
+                      "at most one");
+    }
+  }
+
+
+	/**
+	 * FIXME : woonhak, add this too */
+
+  /**
+   * Convert a byte array into a valid mysql string literal, assuming that
+   * it will be inserted into a column with latin-1 encoding.
+   * Based on information at
+   * http://dev.mysql.com/doc/refman/5.1/en/string-literals.html
+   * @param arr
+   * @return
+   */
+
+/* XXX woonhak, make string from byte */
+
+/*
+  private static String stringLiteral(byte arr[]) {
+    CharBuffer cb = Charset.forName("UTF8").decode(ByteBuffer.wrap(arr));
+    StringBuilder sb = new StringBuilder();
+
+		// I  think convert charset from utf8 to latin1 can be done in PostgreSQL functions
+		sb.append("convert_from('" + cb.toString() + "', 'UTF8', 'LATIN1')");
+
+    return sb.toString();
+  }
+	*/
+
+  private static String stringLiteral(byte arr[]) {
+    CharBuffer cb = Charset.forName("ISO-8859-1").decode(ByteBuffer.wrap(arr));
+    StringBuilder sb = new StringBuilder();
+    sb.append('\'');
+    for (int i = 0; i < cb.length(); i++) {
+      char c = cb.get(i);
+      switch (c) {
+        case '\'':
+          sb.append("\'\'");
+          break;
+        case '\\':
+          sb.append("\\\\");
+          break;
+        case '\0':
+          sb.append("\\0");
+          break;
+        case '\b':
+          sb.append("\\b");
+          break;
+        case '\n':
+          sb.append("\\n");
+          break;
+        case '\r':
+          sb.append("\\r");
+          break;
+        case '\t':
+          sb.append("\\t");
+          break;
+        default:
+          if (Character.getNumericValue(c) < 0) {
+            // Fall back on hex string for values not defined in latin-1
+            return hexStringLiteral(arr);
+          } else {
+            sb.append(c);
+          }
+      }
+    }
+    sb.append('\'');
+    return sb.toString();
+  }
+
+  /**
+   * Create a mysql hex string literal from array:
+   * E.g. [0xf, bc, 4c, 4] converts to x'0fbc4c03'
+   * @param arr
+   * @return the mysql hex literal including quotes
+   */
+  private static String hexStringLiteral(byte[] arr) {
+    StringBuilder sb = new StringBuilder();
+		/*woonhak, we're going to make PostgreSQL hex*/
+    //sb.append("x'");
+    sb.append("\'\\x");
+
+    for (int i = 0; i < arr.length; i++) {
+      byte b = arr[i];
+      int lo = b & 0xf;
+      int hi = (b >> 4) & 0xf;
+      sb.append(Character.forDigit(hi, 16));
+      sb.append(Character.forDigit(lo, 16));
+    }
+    sb.append("'");
+    return sb.toString();
+  }
+}


### PR DESCRIPTION
Add 
1) maven download for postgresql-jdbc-connector
2) translate MySQL SQL to PostgreSQL - almost file except 'REPLACE INTO' and 'INSERT ON DUPLICATE'
3) text translation : Exploit original LinkBench's Idea, 
Send encoded hex string as 'latin-1', then decode it inside DBMS engine.

Short term test passed.