### PR TITLE
Add higher resolution latency reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,4 @@ out
 *.iml
 .idea
 .DS_Store
-
+.vscode/

--- a/README.md
+++ b/README.md
@@ -334,6 +334,37 @@ so on.
                    p75 = [1,2]ms  p95 = [10,11]ms  p99 = [15,16]ms
                    max = 2064.476ms  mean = 2.427ms
 
+Detailed Latency Data
+---------------------
+
+More detailed latency statistics can be measured by the benchmark using HDRHistogram to approximate
+the values of the percentiles at the trade off of higher memory usage.  This can be enabled by
+setting the following options in the config file (all three must be specified):
+
+    # True to enable HDR Histogram, if false or not present, will use default
+    use_hdr_histogram = true
+
+    # Number of significant digits to approximate, must be within 1-5 inclusive
+    hdr_histogram_accuracy = 5
+
+    # A maximum possible latency value to support in microseconds.  If a latency
+    # value outside this range is detected, the test may fail
+    hdr_histogram_max_latency = 100000000
+
+Higher accuracy and maximum latency settings will increase the memory footprint.  This is estimated
+by the library and will be logged in the output logs to aid sizing:
+
+    Creating HDR histogram with 5 significant digits, 100000000 max latency
+    and memory footprint of 207,627,264 bytes
+
+When enabled, this will give approximate values for the latency percentiles in the logs:
+
+    LOAD_COUNTS_BULK count = 11755  p25 = 258057us p50 = 306573us
+                     p75 = 356099us  p95 = 429589us  p99 = 504841us
+                     max = 1221215.000us mean = 308112.241us threads = 21
+
+This data will also replace the data saved in the output csv file.
+
 Advanced LinkBench Command Line Usage
 -------------------------------------
 Here are some further examples of how to use the LinkBench command link utility.

--- a/pom.xml
+++ b/pom.xml
@@ -45,6 +45,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>org.hdrhistogram</groupId>
+            <artifactId>HdrHistogram</artifactId>
+            <version>2.1.12</version>
+        </dependency>
+        <dependency>
             <groupId>commons-cli</groupId>
             <artifactId>commons-cli</artifactId>
             <version>1.2</version>

--- a/src/main/java/com/facebook/LinkBench/LinkBenchDriver.java
+++ b/src/main/java/com/facebook/LinkBench/LinkBenchDriver.java
@@ -18,6 +18,8 @@ package com.facebook.LinkBench;
 import com.facebook.LinkBench.LinkBenchLoad.LoadChunk;
 import com.facebook.LinkBench.LinkBenchLoad.LoadProgress;
 import com.facebook.LinkBench.LinkBenchRequest.RequestProgress;
+import com.facebook.LinkBench.stats.LatencyHistogram;
+import com.facebook.LinkBench.stats.LatencyHistogramFactory;
 import com.facebook.LinkBench.stats.LatencyStats;
 import com.facebook.LinkBench.stats.SampledStats;
 import com.facebook.LinkBench.util.ClassLoadUtil;
@@ -63,6 +65,7 @@ public class LinkBenchDriver {
   private int dbcount;
 
   private final Logger logger = Logger.getLogger();
+  private final LatencyHistogramFactory latencyHistogramFactory = new LatencyHistogramFactory(logger);
 
   LinkBenchDriver(String configfile, Properties
                   overrideProps, String logFile)
@@ -226,7 +229,7 @@ public class LinkBenchDriver {
     boolean genNodes = ConfigUtil.getBool(props, Config.GENERATE_NODES);
     int nTotalLoaders = genNodes ? nLinkLoaders + 1 : nLinkLoaders;
 
-    LatencyStats latencyStats = new LatencyStats(nTotalLoaders);
+    LatencyHistogram latencyStats = latencyHistogramFactory.create(nTotalLoaders, props);
     List<Runnable> loaders = new ArrayList<Runnable>(nTotalLoaders);
 
     LoadProgress loadTracker = LoadProgress.create(logger, props);
@@ -375,7 +378,7 @@ public class LinkBenchDriver {
       logger.info("NO REQUEST PHASE CONFIGURED. ");
       return;
     }
-    LatencyStats latencyStats = new LatencyStats(nrequesters);
+    LatencyHistogram latencyStats = latencyHistogramFactory.create(nrequesters, props);
     List<LinkBenchRequest> requesters = new LinkedList<LinkBenchRequest>();
 
     RequestProgress progress = LinkBenchRequest.createProgress(logger, props);

--- a/src/main/java/com/facebook/LinkBench/LinkBenchLoad.java
+++ b/src/main/java/com/facebook/LinkBench/LinkBenchLoad.java
@@ -26,6 +26,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import com.facebook.LinkBench.distributions.ID2Chooser;
 import com.facebook.LinkBench.distributions.LogNormalDistribution;
 import com.facebook.LinkBench.generators.DataGenerator;
+import com.facebook.LinkBench.stats.LatencyHistogram;
 import com.facebook.LinkBench.stats.LatencyStats;
 import com.facebook.LinkBench.stats.SampledStats;
 import com.facebook.LinkBench.util.ClassLoadUtil;
@@ -54,7 +55,7 @@ public class LinkBenchLoad implements Runnable {
   private final LogNormalDistribution linkDataSize;
   private final DataGenerator linkDataGen; // Generate link data
   private SampledStats stats;
-  private LatencyStats latencyStats;
+  private LatencyHistogram latencyStats;
 
   Level debuglevel;
   String dbid;
@@ -97,7 +98,7 @@ public class LinkBenchLoad implements Runnable {
    * @param nloaders
    */
   public LinkBenchLoad(LinkStore store, Properties props,
-      LatencyStats latencyStats, PrintStream csvStreamOut,
+      LatencyHistogram latencyStats, PrintStream csvStreamOut,
       int loaderID, boolean singleAssoc,
       int nloaders, LoadProgress prog_tracker, Random rng) {
     this(store, props, latencyStats, csvStreamOut, loaderID, singleAssoc,
@@ -115,7 +116,7 @@ public class LinkBenchLoad implements Runnable {
 
   public LinkBenchLoad(LinkStore linkStore,
                        Properties props,
-                       LatencyStats latencyStats,
+                       LatencyHistogram latencyStats,
                        PrintStream csvStreamOut,
                        int loaderID,
                        boolean singleAssoc,
@@ -631,7 +632,7 @@ public class LinkBenchLoad implements Runnable {
       long nids = (maxid1 - startid1) * ConfigUtil.getInt(props, Config.DBCOUNT, 1);
       long progressReportInterval = ConfigUtil.getLong(props,
                            Config.LOAD_PROG_INTERVAL, 50000L);
-      boolean nc = false; 
+      boolean nc = false;
       if (props.containsKey(Config.NEVER_CHANGE))
         nc = ConfigUtil.getBool(props, Config.NEVER_CHANGE);
       return new LoadProgress(progressLogger, nids, progressReportInterval, nc);

--- a/src/main/java/com/facebook/LinkBench/LinkBenchRequest.java
+++ b/src/main/java/com/facebook/LinkBench/LinkBenchRequest.java
@@ -26,6 +26,7 @@ import com.facebook.LinkBench.distributions.ID2Chooser;
 import com.facebook.LinkBench.distributions.LogNormalDistribution;
 import com.facebook.LinkBench.distributions.ProbabilityDistribution;
 import com.facebook.LinkBench.generators.DataGenerator;
+import com.facebook.LinkBench.stats.LatencyHistogram;
 import com.facebook.LinkBench.stats.LatencyStats;
 import com.facebook.LinkBench.stats.SampledStats;
 import com.facebook.LinkBench.util.ClassLoadUtil;
@@ -136,7 +137,7 @@ public class LinkBenchRequest implements Runnable {
 
   // Statistics
   SampledStats stats;
-  LatencyStats latencyStats;
+  LatencyHistogram latencyStats;
 
   // Other informational counters
   long numfound = 0;
@@ -175,7 +176,7 @@ public class LinkBenchRequest implements Runnable {
   public LinkBenchRequest(LinkStore linkStore,
                           NodeStore nodeStore,
                           Properties props,
-                          LatencyStats latencyStats,
+                          LatencyHistogram latencyStats,
                           PrintStream csvStreamOut,
                           RequestProgress progressTracker,
                           Random rng,
@@ -570,7 +571,7 @@ public class LinkBenchRequest implements Runnable {
           wr = linkStore.updateLink(dbid, link, true);
         }
         boolean found = (wr == LinkWriteResult.LINK_NO_CHANGE ||
-                         wr == LinkWriteResult.LINK_UPDATE); 
+                         wr == LinkWriteResult.LINK_UPDATE);
         endtime = System.nanoTime();
         if (Level.TRACE.isGreaterOrEqual(debuglevel)) {
           logger.trace("updateLink id1=" + link.id1 + " link_type="

--- a/src/main/java/com/facebook/LinkBench/NodeLoader.java
+++ b/src/main/java/com/facebook/LinkBench/NodeLoader.java
@@ -23,6 +23,7 @@ import java.util.Random;
 
 import com.facebook.LinkBench.distributions.LogNormalDistribution;
 import com.facebook.LinkBench.generators.DataGenerator;
+import com.facebook.LinkBench.stats.LatencyHistogram;
 import com.facebook.LinkBench.stats.LatencyStats;
 import com.facebook.LinkBench.stats.SampledStats;
 import com.facebook.LinkBench.util.ClassLoadUtil;
@@ -48,7 +49,7 @@ public class NodeLoader implements Runnable {
   private final Level debuglevel;
   private final int loaderId;
   private final SampledStats stats;
-  private final LatencyStats latencyStats;
+  private final LatencyHistogram latencyStats;
 
   private String dbid;
   private String dbprefix;
@@ -73,7 +74,7 @@ public class NodeLoader implements Runnable {
 
   public NodeLoader(Properties props, Logger logger,
       NodeStore nodeStore, Random rng,
-      LatencyStats latencyStats, PrintStream csvStreamOut, int loaderId) {
+      LatencyHistogram latencyStats, PrintStream csvStreamOut, int loaderId) {
     super();
     this.props = props;
     this.logger = logger;

--- a/src/main/java/com/facebook/LinkBench/stats/HdrLatencyHistogram.java
+++ b/src/main/java/com/facebook/LinkBench/stats/HdrLatencyHistogram.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright 2021-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.LinkBench.stats;
+
+import java.io.PrintStream;
+import java.text.DecimalFormat;
+
+import com.facebook.LinkBench.LinkBenchOp;
+import com.facebook.LinkBench.LinkStore;
+import com.facebook.LinkBench.Logger;
+import org.HdrHistogram.Histogram;
+
+/**
+ * Class used to track latency values using HDR Histogram.  This provides
+ * a more accurate estimate of the latency percentiles at a cost of a higher
+ * memory footprint than the default histogram type
+ *
+ * See http://hdrhistogram.org/ for more details
+ */
+public class HdrLatencyHistogram implements LatencyHistogram {
+
+  private static final int percentiles[] = new int[] {25, 50, 75, 95, 99};
+  private final Histogram histograms[];
+  private final int maxThreads;
+
+  public HdrLatencyHistogram(int maxThreads, int histogramAccuracy, int maxHistogramValue) {
+    this.maxThreads = maxThreads;
+    histograms = new Histogram[LinkStore.MAX_OPTYPES];
+    for (LinkBenchOp op : LinkBenchOp.values()) {
+      histograms[op.ordinal()] = new Histogram(maxHistogramValue, histogramAccuracy);
+    }
+  }
+
+  /**
+   * Get an estimate of the amount of memory that will be used by the histogram
+   */
+  public long memoryUsageEstimate() {
+    long usageInBytes = 0;
+    for(Histogram histogram : histograms)
+    {
+      usageInBytes += histogram.getEstimatedFootprintInBytes();
+    }
+
+    return usageInBytes;
+  }
+
+  /**
+   * Track a latency value for a specific operation
+   */
+  @Override
+  public void recordLatency(int threadid, LinkBenchOp type, long microtimetaken) {
+    histograms[type.ordinal()].recordValue(microtimetaken);
+  }
+
+  /**
+   * Print the current latency stats tracked to the logs
+   */
+  @Override
+  public void displayLatencyStats() {
+    Logger logger = Logger.getLogger();
+    // print percentiles
+    for (LinkBenchOp type: LinkBenchOp.values()) {
+
+      Histogram histogram = histograms[type.ordinal()];
+      if (histogram.getTotalCount() == 0) { // no samples of this type
+        continue;
+      }
+
+      long sampleCounts = histogram.getTotalCount();
+      String logString = type.displayName() + String.format(" count = %d ", sampleCounts);
+      for(int percentile: percentiles) {
+        logString += String.format(" p%d = %dus ", percentile, histogram.getValueAtPercentile(percentile));
+      }
+
+      double mean = histogram.getMean();
+      long max = histogram.getMaxValue();
+      logString += String.format(" max = %dus mean = %.3fus threads = %d", max, mean, maxThreads);
+      logger.info(logString);
+    }
+  }
+
+  /**
+   * Print the current latency stats in csv format
+   */
+  @Override
+  public void printCSVStats(PrintStream out, boolean header) {
+    printCSVStats(out, header, LinkBenchOp.values());
+  }
+
+  private void printCSVStats(PrintStream out, boolean header, LinkBenchOp... ops) {
+
+    // Write out the header
+    if (header) {
+      out.print("op,count");
+      for (int percentile: percentiles) {
+        out.print(String.format(",p%d (us)", percentile));
+      }
+
+      out.print(",max (us),mean (us),threads");
+      out.println();
+    }
+
+    DecimalFormat df = new DecimalFormat("#.##");
+    for (LinkBenchOp op: ops) {
+      Histogram histogram = histograms[op.ordinal()];
+      long samples = histogram.getTotalCount();
+      if (samples == 0) {
+        continue;
+      }
+
+      out.print(op.name());
+      out.print(",");
+      out.print(samples);
+
+      for (int percentile: percentiles) {
+        double percentileValue = histogram.getValueAtPercentile(percentile);
+        out.print(",");
+        out.print(df.format(percentileValue));
+      }
+
+      String max = df.format(histogram.getMaxValueAsDouble());
+      String mean = df.format(histogram.getMean());
+
+      out.print(",");
+      out.print(max);
+      out.print(",");
+      out.print(mean);
+      out.print(",");
+      out.print(maxThreads);
+      out.println();
+    }
+  }
+}

--- a/src/main/java/com/facebook/LinkBench/stats/LatencyHistogram.java
+++ b/src/main/java/com/facebook/LinkBench/stats/LatencyHistogram.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2021-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.facebook.LinkBench.stats;
+
+import java.io.PrintStream;
+
+import com.facebook.LinkBench.LinkBenchOp;
+
+public interface LatencyHistogram {
+
+    /**
+     * Record a latency value from a test
+     * @param threadid the thread that is reporting the latency
+     * @param type the type of operation that the latency is from
+     * @param microtimetaken the time taken, in microseconds, for the operation to complete
+     */
+    public void recordLatency(int threadid, LinkBenchOp type,
+        long microtimetaken);
+
+    /**
+     * Print statistics about latency to the logs
+     */
+    public void displayLatencyStats();
+
+    /**
+     * Save the latency results in csv format
+     * @param out the stream to write the csv data to
+     * @param header true if the header values of the csv should be printed
+     */
+    public void printCSVStats(PrintStream out, boolean header);
+}

--- a/src/main/java/com/facebook/LinkBench/stats/LatencyHistogramFactory.java
+++ b/src/main/java/com/facebook/LinkBench/stats/LatencyHistogramFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2021-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.LinkBench.stats;
+
+import java.util.Properties;
+
+import com.facebook.LinkBench.ConfigUtil;
+
+import com.facebook.LinkBench.Logger;
+
+public class LatencyHistogramFactory {
+
+    private final Logger logger;
+
+    public LatencyHistogramFactory(Logger logger) {
+        this.logger = logger;
+    }
+
+    /**
+     * Create a latency histogram for a test given the config options
+     * @param maxThreads the number of threads used by the test
+     * @param props the properties from the linkbench config file
+     * @return the histogram for recording latency results
+     */
+    public LatencyHistogram create(int maxThreads, Properties props)
+    {
+        String useHdr = props.getProperty("use_hdr_histogram");
+        if (Boolean.valueOf(useHdr))
+        {
+            int histogramAccuracy = ConfigUtil.getInt(props, "hdr_histogram_accuracy");
+            int maxHistogramValue = ConfigUtil.getInt(props, "hdr_histogram_max_latency");
+
+            HdrLatencyHistogram histogram = new HdrLatencyHistogram(maxThreads, histogramAccuracy, maxHistogramValue);
+            logger.info(String.format(
+                "Creating HDR histogram with %d significant digits, %d max latency, and memory footprint of %d bytes",
+                histogramAccuracy,
+                maxHistogramValue,
+                histogram.memoryUsageEstimate()));
+
+            return histogram;
+        }
+
+        // Using default latency tracking (lower memory footprint with reduced accuracy)
+        return new LatencyStats(maxThreads);
+    }
+}

--- a/src/main/java/com/facebook/LinkBench/stats/LatencyStats.java
+++ b/src/main/java/com/facebook/LinkBench/stats/LatencyStats.java
@@ -33,7 +33,7 @@ import com.facebook.LinkBench.Level;
  * we have 0.1ms-granularity buckets up to 1ms, then 1ms-granularity from
  * 1-100ms, then 100ms-granularity, and then 1s-granularity.
  */
-public class LatencyStats {
+public class LatencyStats implements LatencyHistogram {
 
   public static int MAX_MILLIS = 100;
 

--- a/src/test/java/com/facebook/LinkBench/LinkStoreTestBase.java
+++ b/src/test/java/com/facebook/LinkBench/LinkStoreTestBase.java
@@ -35,6 +35,7 @@ import com.facebook.LinkBench.distributions.ZipfDistribution;
 import com.facebook.LinkBench.distributions.LinkDistributions.LinkDistMode;
 import com.facebook.LinkBench.distributions.UniformDistribution;
 import com.facebook.LinkBench.generators.UniformDataGenerator;
+import com.facebook.LinkBench.stats.LatencyHistogram;
 import com.facebook.LinkBench.stats.LatencyStats;
 
 /**
@@ -698,7 +699,7 @@ public abstract class LinkStoreTestBase extends TestCase {
       serialLoad(rng, logger, props, getStoreHandle(false));
 
       DummyLinkStore reqStore = getStoreHandle(false);
-      LatencyStats latencyStats = new LatencyStats(1);
+      LatencyHistogram latencyStats = new LatencyStats(1);
       RequestProgress tracker = new RequestProgress(logger, requests, timeLimit, 0, 1000);
 
       statusOut("testRequester: request");
@@ -826,7 +827,7 @@ public abstract class LinkStoreTestBase extends TestCase {
 
       DummyLinkStore reqStore = getStoreHandle(false);
       reqStore.setRangeLimit(rangeLimit); // Small limit for testing
-      LatencyStats latencyStats = new LatencyStats(1);
+      LatencyHistogram latencyStats = new LatencyStats(1);
       LinkBenchRequest requester = new LinkBenchRequest(reqStore, null,
                       props, latencyStats, System.out, tracker, rng, 0, 1);
 
@@ -883,7 +884,7 @@ public abstract class LinkStoreTestBase extends TestCase {
    */
   static void serialLoad(Random rng, Logger logger, Properties props,
       DummyLinkStore store) throws IOException, Exception {
-    LatencyStats latencyStats = new LatencyStats(1);
+    LatencyHistogram latencyStats = new LatencyStats(1);
 
     /* Load up queue with work */
     LinkedBlockingQueue<LoadChunk>  chunk_q = new LinkedBlockingQueue<LoadChunk>();

--- a/src/test/java/com/facebook/LinkBench/TestHdrLatencyHistogram.java
+++ b/src/test/java/com/facebook/LinkBench/TestHdrLatencyHistogram.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2021-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.LinkBench;
+
+import java.io.PrintStream;
+import java.io.ByteArrayOutputStream;
+import java.lang.ArrayIndexOutOfBoundsException;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+import com.facebook.LinkBench.stats.HdrLatencyHistogram;
+import com.facebook.LinkBench.stats.LatencyHistogram;
+
+public class TestHdrLatencyHistogram {
+
+  private static final String header =
+      "op,count,p25 (us),p50 (us),p75 (us),p95 (us),p99 (us),max (us),mean (us),threads\n";
+
+  @Test
+  public void testSimpleDistribution() {
+    LatencyHistogram histogram = new HdrLatencyHistogram(8, 3, 100);
+
+    for(int i = 1; i <= 100; i++)
+    {
+      histogram.recordLatency(0, LinkBenchOp.ADD_LINK, i);
+    }
+
+    String result = getCsvResults(histogram);
+    String metrics = "ADD_LINK,100,25,50,75,95,99,100,50.5,8\n";
+
+    assertEquals(header + metrics, result);
+  }
+
+  @Test
+  public void testNoDataPoints() {
+    LatencyHistogram histogram = new HdrLatencyHistogram(8, 3, 100);
+    String results = getCsvResults(histogram);
+    assertEquals(header, results);
+  }
+
+  @Test
+  public void testNoHeaderNoData() {
+    LatencyHistogram histogram = new HdrLatencyHistogram(8, 3, 100);
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(os);
+
+    histogram.printCSVStats(ps, false);
+    String result = os.toString();
+
+    assertEquals("", result);
+  }
+
+  @Test
+  public void testLogsLatencyValues() {
+    HdrLatencyHistogram histogram = new HdrLatencyHistogram(8, 3, 5);
+    histogram.recordLatency(0, LinkBenchOp.ADD_LINK, 1);
+    histogram.displayLatencyStats();
+  }
+
+  @Test
+  public void testLogNoStats() {
+    HdrLatencyHistogram histogram = new HdrLatencyHistogram(8, 3, 5);
+    histogram.displayLatencyStats();
+  }
+
+  @Test(expected = ArrayIndexOutOfBoundsException.class)
+  public void testOverMax() throws ArrayIndexOutOfBoundsException {
+    HdrLatencyHistogram histogram = new HdrLatencyHistogram(8, 3, 5);
+    histogram.recordLatency(0, LinkBenchOp.ADD_LINK, 1000000);
+  }
+
+  String getCsvResults(LatencyHistogram histogram) {
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    PrintStream ps = new PrintStream(os);
+    histogram.printCSVStats(ps, true);
+    return os.toString();
+  }
+}

--- a/src/test/java/com/facebook/LinkBench/TestLatencyHistogramFactory.java
+++ b/src/test/java/com/facebook/LinkBench/TestLatencyHistogramFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Copyright 2021-present MongoDB Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.facebook.LinkBench;
+
+import java.util.Properties;
+
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+import com.facebook.LinkBench.stats.HdrLatencyHistogram;
+import com.facebook.LinkBench.stats.LatencyHistogram;
+import com.facebook.LinkBench.stats.LatencyHistogramFactory;
+import com.facebook.LinkBench.stats.LatencyStats;
+
+public class TestLatencyHistogramFactory {
+
+  private static final Logger logger = Logger.getLogger();
+
+  @Test(expected = LinkBenchConfigError.class)
+  public void testMissingBothConfigs() {
+    Properties props = new Properties();
+    props.setProperty("use_hdr_histogram", "true");
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+    factory.create(8, props);
+  }
+
+  @Test(expected = LinkBenchConfigError.class)
+  public void testMissingAccuracyConfig() {
+    Properties props = new Properties();
+    props.setProperty("use_hdr_histogram", "true");
+    props.setProperty("hdr_histogram_max_latency", "8");
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+    factory.create(8, props);
+  }
+
+  @Test(expected = LinkBenchConfigError.class)
+  public void testMissingMaxLatencyConfig() {
+    Properties props = new Properties();
+    props.setProperty("use_hdr_histogram", "true");
+    props.setProperty("hdr_histogram_accuracy", "8");
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+    factory.create(8, props);
+  }
+
+  @Test(expected = LinkBenchConfigError.class)
+  public void testConfigsNotNumbers() {
+    Properties props = new Properties();
+    props.setProperty("use_hdr_histogram", "true");
+    props.setProperty("hdr_histogram_accuracy", "test");
+    props.setProperty("hdr_histogram_max_latency", "test");
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+    factory.create(8, props);
+  }
+
+  @Test
+  public void testUseHistogramNotBool() {
+    Properties props = new Properties();
+    props.setProperty("use_hdr_histogram", "test");
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+
+    LatencyHistogram histogram = factory.create(8, props);
+
+    assertTrue(histogram instanceof LatencyStats);
+  }
+
+  @Test
+  public void testUseHistogramFalse() {
+    Properties props = new Properties();
+    props.setProperty("use_hdr_histogram", "false");
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+
+    LatencyHistogram histogram = factory.create(8, props);
+
+    assertTrue(histogram instanceof LatencyStats);
+  }
+
+  @Test
+  public void testUseHistogramNothingSpecified() {
+    Properties props = new Properties();
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+    LatencyHistogram histogram = factory.create(8, props);
+    assertTrue(histogram instanceof LatencyStats);
+  }
+
+
+  @Test
+  public void testUseHistogramAllSpecified() {
+    Properties props = new Properties();
+    props.setProperty("use_hdr_histogram", "true");
+    props.setProperty("hdr_histogram_accuracy", "5");
+    props.setProperty("hdr_histogram_max_latency", "100");
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+
+    LatencyHistogram histogram = factory.create(8, props);
+
+    assertTrue(histogram instanceof HdrLatencyHistogram);
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void testUseHistogramAccuracyTooHigh() {
+    Properties props = new Properties();
+    props.setProperty("use_hdr_histogram", "true");
+    props.setProperty("hdr_histogram_accuracy", "100");
+    props.setProperty("hdr_histogram_max_latency", "100");
+    LatencyHistogramFactory factory = new LatencyHistogramFactory(logger);
+
+    factory.create(8, props);
+  }
+}


### PR DESCRIPTION
This change adds a secondary method for tracking latency data using [HDRHistogram](http://hdrhistogram.org/)  It adds new configuration parameters to switch between the latency histogram types and configure the accuracy of the report.